### PR TITLE
Support React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Andarist/use-constant#readme",
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",


### PR DESCRIPTION
Thanks for this library! This is a common utility that I use in projects and I'm glad to see that there's an open source version of this.

Just out of curiosity: Is there a reason why the lazy initialized value is written to a `v` property instead of to `current` directly?

Thanks!