### PR TITLE
update peer dependencies to include React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-constant",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React hook for creating a value exactly once.",
   "main": "./dist/use-constant.cjs.js",
   "module": "./dist/use-constant.esm.js",
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Andarist/use-constant#readme",
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-constant",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "React hook for creating a value exactly once.",
   "main": "./dist/use-constant.cjs.js",
   "module": "./dist/use-constant.esm.js",


### PR DESCRIPTION
Fixes peer dependency warnings when using React 18 😊 closes #8 